### PR TITLE
feat: adding mint address validation at create

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -7,7 +7,6 @@ use solana_program::{
     program_error::PrintProgramError,
     program_error::ProgramError,
     program_pack::Pack,
-    pubkey,
     pubkey::Pubkey,
     rent::Rent,
     system_instruction::create_account,
@@ -23,6 +22,9 @@ use crate::{
     instruction::{Schedule, VestingInstruction},
     state::{pack_schedule_into_slice, unpack_schedule, VestingSchedule, VestingScheduleHeader},
 };
+
+pub const VALID_TOKEN_MINT: Pubkey =
+    solana_program::pubkey!("AxfBPA1yi6my7VAjqB9fqr1AgYczuuJy8tePnNUDDPpW");
 
 pub struct Processor {}
 
@@ -91,12 +93,9 @@ impl Processor {
         mint_address: &Pubkey,
         schedule: Schedule,
     ) -> ProgramResult {
-        // Define the required mint address
-        const TOKEN_MINT_ADDRESS: Pubkey = pubkey!("AxfBPA1yi6my7VAjqB9fqr1AgYczuuJy8tePnNUDDPpW");
-
         // Validate the mint address matches the expected token address
-        if *mint_address != TOKEN_MINT_ADDRESS {
-            msg!("Invalid mint address: Only 'TokenABCD' is supported.");
+        if *mint_address != VALID_TOKEN_MINT {
+            msg!("Unsuported token mint address");
             return Err(ProgramError::InvalidArgument);
         }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -7,6 +7,7 @@ use solana_program::{
     program_error::PrintProgramError,
     program_error::ProgramError,
     program_pack::Pack,
+    pubkey,
     pubkey::Pubkey,
     rent::Rent,
     system_instruction::create_account,
@@ -75,6 +76,15 @@ impl Processor {
         mint_address: &Pubkey,
         schedule: Schedule,
     ) -> ProgramResult {
+        // Define the required mint address
+        const TOKEN_MINT_ADDRESS: Pubkey = pubkey!("AxfBPA1yi6my7VAjqB9fqr1AgYczuuJy8tePnNUDDPpW");
+
+        // Validate the mint address matches the expected token address
+        if *mint_address != TOKEN_MINT_ADDRESS {
+            msg!("Invalid mint address: Only 'TokenABCD' is supported.");
+            return Err(ProgramError::InvalidArgument);
+        }
+
         let accounts_iter = &mut accounts.iter();
 
         let spl_token_account = next_account_info(accounts_iter)?;


### PR DESCRIPTION
Fixes HAL-002

> ## Description
> After the user invokes the process_init entry point, they need to invoke the process_create entry point to store the necessary information to participate in the token locking process.
> 
> A piece of information that the user has to provide is the source token account, where the tokens will be subtracted to participate.
> 
> The mentioned token account is not validated to be a token account corresponding to the L3 token, which is expected to be the token used.
> 
> As a result, any user can create a vesting_account that does with any token different than L3 token.
> 
> The L3 team mentioned that this situation does not represent a risk, since the information on chain will be used on an off-chain process.
> 
> However, it is considered a good practice to restrict the functionalities of a program used in production to narrow down the attack surface in order to prevent unexpected behaviors.